### PR TITLE
Fix not returning empty string when "refs/heads/" is not found in .git/HEAD

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,10 +52,12 @@ func gitBranch(path string) string {
 		return ""
 	}
 
-	i := bytes.Index(b, []byte("refs/heads/")) + len("refs/heads/")
+	const prefix = []byte("refs/heads/")
+	i := bytes.Index(b, prefix)
 	if i == -1 {
 		return ""
 	}
+	i += len(prefix)
 
 	return strings.TrimSpace(string(b[i:]))
 }


### PR DESCRIPTION
[`bytes.Index()`](https://golang.org/pkg/bytes/#Index) will return `-1` if the string isn't found. Unfortunately, I was adding `len("refs/heads/")` to the result of `bytes.Index()`. So the result was always `10` or greater. This would cause `gitBranch()` to return a non-empty string if `.git/HEAD` contained unexpected input.