### PR TITLE
Add LTO and disable parallel compilation when building release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2018"
 license = "MIT"
 description = "Generate a zsh prompt that prints the current branch name with colors."
 
-[dependencies]
+[profile.release]
+codegen-units = 1
+lto = true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a tiny little program that prints the current git branch in oh-my-zsh style. The 💩 means the repo is [dirty](https://stackoverflow.com/questions/20642980/does-git-dirty-mean-files-not-staged-or-not-committed-glossary-conflict).
 
 You can use it like this:
+
 ```sh
 # enable running shell commands in the prompt string
 setopt prompt_subst


### PR DESCRIPTION
* `codegen-units = 1` disables parallel compilation, which enables some extra optimizations.
* LTO (link-time optimization) defers optimizing the binary until after the linking step. This allows optimizations across linking boundaries.

None of this matters at all. I'm just trying to apply stuff I've learned recently so I can remember it.